### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This package contains generated Python types for ``google.appengine.logging.v1.r
 - `Product Documentation`_
 
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-appengine-logging.svg
    :target: https://pypi.org/project/google-cloud-appengine-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-logging.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.