### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "appenginelogging",
     "name_pretty": "App Engine Logging Protos",
     "product_documentation": "https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1",
-    "client_documentation": "https://googleapis.dev/python/appenginelogging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/appenginelogging/latest",
     "issue_tracker": "https://github.com/googleapis/python-appenginelogging/issues",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.