### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "appenginelogging",
     "name_pretty": "App Engine Logging Protos",
     "product_documentation": "https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1",
-    "client_documentation": "https://googleapis.dev/python/appenginelogging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/appenginelogging/latest",
     "issue_tracker": "https://github.com/googleapis/python-appenginelogging/issues",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This package contains generated Python types for ``google.appengine.logging.v1.r
    :target: https://pypi.org/project/google-cloud-appengine-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-logging.svg
    :target: https://pypi.org/project/google-cloud-appengine-logging/
-.. _Client Library Documentation: https://googleapis.dev/python/appenginelogging/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appenginelogging/latest
 .. _Product Documentation:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
 
 


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.